### PR TITLE
Fix Give Keys

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -718,13 +718,12 @@ Config.MenuItems = {
                 event = 'qb-phone:client:GiveContactDetails',
                 shouldClose = true
             },{
-                
-                id = 'givekey',
+                id = 'givekeys',
                 title = 'Give Vehicle Keys',
                 icon = 'key',
-                type = 'client',
-                event = 'qb-vehiclekeys:client:GiveKeys',
-                shouldClose = true                
+                type = 'command',
+                event = 'givekeys',
+                shouldClose = true                 
             },{
                 id = 'getintrunk',
                 title = 'Get In Trunk',


### PR DESCRIPTION
Event doesn't work in the new updated qb-vehiclekeys. The Command is now a thing.